### PR TITLE
fix Routes documentation typo

### DIFF
--- a/docs/src/pages/guides/routes.md
+++ b/docs/src/pages/guides/routes.md
@@ -23,7 +23,7 @@ A route path can be a string _(regular expression support is coming soon!)_, and
 - `/about`
 - `about/`
 - `about`
-- `About'
+- `About`
 
 > **Important:** Route paths are **not case-sensitive** by default. This means that `/about` and `/About` are considered the same path. This is a good thing, since this is the way most of the web works anyway! However, if you truly want to match a path with a different case, you can set a route's `caseSensitive` property to `true`.
 


### PR DESCRIPTION
Replaces a mistaken sing-quote with a back-tick for formatting purposes

![CleanShot 2022-02-06 at 13 29 04@2x](https://user-images.githubusercontent.com/17390173/152698049-7be32222-d9c1-4ca0-a01b-47d2cde59e66.png)
