### PR TITLE
fix: rollup umd output name

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -199,7 +199,7 @@ function umdProd({
     output: {
       format: 'umd',
       sourcemap: true,
-      file: `${packageDir}/build/umd/index.production.js`,
+      file: `${packageDir}/build/umd/index.production.min.js`,
       name: jsName,
       globals,
       banner,


### PR DESCRIPTION
After [#780ae4](https://github.com/TanStack/react-location/commit/780ae4072e9e150d987bbd1d3ef30ace3078d5e5), rollup started outputting the UMD bundle as `/build/umd/index.production.js` instead of `/build/umd/index.production.min.js`. This breaks build tools (Vite, Parcel, etc.) that use the `browser` value from each packages `package.json`.

I figured the correct output would be `/build/umd/index.production.min.js`, but we might want to update each package's `browser` value instead to point to the new `/build/umd/index.production.js`.

I was going through this issue in a project using Parcel v2. I tested this change by applying this change, running `yarn run build` and `yarn run linkAll`, and linking the libraries locally. My test project did use all packages, only `react-location` and `react-location-jsurl`.

Fixes #220 
Fixes #216