### PR TITLE
Fix with-cache example project with missing dependency and duplicate route key issue

### DIFF
--- a/examples/with-simple-cache/package.json
+++ b/examples/with-simple-cache/package.json
@@ -7,13 +7,14 @@
     "eject": "rescripts eject"
   },
   "dependencies": {
+    "@tanstack/react-location": "3.6.1",
+    "@tanstack/react-location-simple-cache": "^3.4.4",
     "@types/react": "^17.0.33",
     "@types/react-dom": "^17.0.10",
     "axios": "^0.21.1",
     "broadcast-channel": "^3.4.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "@tanstack/react-location": "3.6.1",
     "react-scripts": "3.0.1",
     "stop-runaway-react-effects": "^1.2.0",
     "styled-components": "^4.3.2"

--- a/examples/with-simple-cache/src/index.tsx
+++ b/examples/with-simple-cache/src/index.tsx
@@ -40,7 +40,7 @@ function App() {
           element: <Index />,
           children: [
             {
-              path: "/",
+              path: "/home",
               element: "Welcome Home!",
             },
             {
@@ -83,7 +83,7 @@ function Index() {
       <h1>Basic With Simple Cache</h1>
       <hr />
       <h2>
-        <Link to=".">Home</Link>{" "}
+        <Link to="/home">Home</Link>{" "}
         <Link to="posts" preload={1}>
           Posts {isLoading ? "..." : ""}
         </Link>


### PR DESCRIPTION
The code sandbox widget was throwing errors due to missing dependency in the package JSON file in this Demo URL.

```
https://react-location.tanstack.com/examples/with-simple-cache
```

<img width="1448" alt="Screen Shot 2022-03-03 at 2 01 25 AM" src="https://user-images.githubusercontent.com/4932290/156456957-9442238e-9ae1-47a9-8cdf-b58f52d27aa3.png">

This PR fixes that issue and also, updated the path for the homepage route to `/home` since the demo page was throwing errors due to duplicate keys.

<img width="697" alt="Screen Shot 2022-03-03 at 2 03 30 AM" src="https://user-images.githubusercontent.com/4932290/156457261-d45f5ea7-6543-4466-a257-786d32e6dc5f.png">

