### PR TITLE
fix: make disabled prop work correctly on Link

### DIFF
--- a/packages/react-location/src/index.tsx
+++ b/packages/react-location/src/index.tsx
@@ -1389,6 +1389,7 @@ export const Link = function Link<
 
   // The click handler
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (disabled) return
     if (onClick) onClick(e)
 
     if (


### PR DESCRIPTION
This change will prevent a `<Link />` element from navigating if the disabled prop is true,

The route will still prefetch on hover when disabled which I could also disable if requested.

Fixes #230 