### PR TITLE
chore: add browserslist config

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,7 @@
+# Browsers we support
+Chrome >= 73
+ChromeAndroid >= 75
+Firefox >= 67
+Edge >= 17
+Safari >= 12.1
+iOS >= 11.3


### PR DESCRIPTION
Hi @tannerlinsley, thank you for making nice libraries!

fix #227 

## Problem?

After 780ae4072e9e150d987bbd1d3ef30ace3078d5e5, this library depends on `regeneratorRuntime` but does not include it.

## Suggestion

No target is specified for @babel/preset-env,
[the default configuration](https://babeljs.io/docs/en/options#no-targets) is applied and async functions are converted to `regeneratorRuntime`.

So my suggestion is to add `.browserslistrc` (not includes IE) and deploy async functions. 

Config file in this PR is based on [react-router configuration](https://github.com/remix-run/react-router/blob/7dca9dc38c837ed94796325b1e0582aa72a9313f/.browserslistrc).