### PR TITLE
Fix initial entries example for createMemoryHistory

### DIFF
--- a/docs/src/pages/guides/history-types-and-location.md
+++ b/docs/src/pages/guides/history-types-and-location.md
@@ -64,7 +64,9 @@ Memory routing is useful in environments that are not a browser, like `node.js` 
 import { createMemoryHistory, ReactLocation } from '@tanstack/react-location'
 
 // Create a memory history
-const memoryHistory = createMemoryHistory('/') // Pass your initial url
+const memoryHistory = createMemoryHistory({
+  initialEntries: ['/'] // Pass your initial url
+})
 
 // Set up a ReactLocation instance with the memory history
 const location = new ReactLocation({


### PR DESCRIPTION
I was trying to use the initial URL for `createMemoryHistory` from the examples and it was not working. I looked through the history package docs and this is the proper way for setting the `initialEntries` to set a default URL.