### PR TITLE
fix: fixed api useSearch MyLocationGenerics typo

### DIFF
--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -490,8 +490,7 @@ type MyLocationGenerics = MakeGenerics<{
       }
       desc?: boolean
     }
-  }>
->
+}>
 
 function MyComponent() {
   const search = useSearch<MyLocationGenerics>()


### PR DESCRIPTION
### What is the change?

In react-location [api document](https://react-location.tanstack.com/docs/api#usesearch) with `useSearch` hook.
there is wrong typo in example code.

AS-IS
```ts
 type MyLocationGenerics = MakeGenerics<{
     Search: {
       pagination?: {
         index?: number
         size?: number
       }
       filters?: {
         name?: string
       }
       desc?: boolean
     }
   }>
 >
```

TO-BE
```ts
type MyLocationGenerics = MakeGenerics<{
    Search: {
      pagination?: {
        index?: number
        size?: number
      }
      filters?: {
        name?: string
      }
      desc?: boolean
    }
}>
```